### PR TITLE
Added an option to specify optional XOR key to use with each hash value

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -67,6 +67,7 @@ logger = Logger(session_id=0, logger_name=__name__)
 
 DEFAULT_ENUM_NAME = "hashdb_strings"
 DEFAULT_API_URL = "https://hashdb.openanalysis.net"
+DEFAULT_XOR_KEY = ""
 HASHDB_PLUGIN_SETTINGS: List[Tuple[str, dict]] = [
     (
         "hashdb.url",
@@ -108,6 +109,16 @@ HASHDB_PLUGIN_SETTINGS: List[Tuple[str, dict]] = [
             "enumDescriptions": ["unsigned int (4 bytes)", "unsigned long (8 bytes)"],
             "description": "Data type and data size of the hash algorithm used for the current binary. This setting is specific to a particular analysis database.",
             "ignore": ["SettingsUserScope", "SettingsProjectScope"],
+        },
+    ),
+    (
+        "hashdb.xor_key",
+        {
+            "title": "HashDB Hash Algorithm Optional XOR key",
+            "type": "string",
+            "default": DEFAULT_XOR_KEY,
+            "description": "Optional XOR key to use with each hash value (common technique used by malware authors)",
+            "ignore": ["SettingsProjectScope", "SettingsResourceScope"],
         },
     ),
 ]

--- a/__init__.py
+++ b/__init__.py
@@ -117,8 +117,8 @@ HASHDB_PLUGIN_SETTINGS: List[Tuple[str, dict]] = [
             "title": "HashDB Hash Algorithm Optional XOR key",
             "type": "string",
             "default": DEFAULT_XOR_KEY,
-            "description": "Optional XOR key to use with each hash value (common technique used by malware authors)",
-            "ignore": ["SettingsProjectScope", "SettingsResourceScope"],
+            "description": "Optional XOR key to use with each hash value (common technique used by malware authors). This should be a hexadecimal value, e.g. 0x1234ABEF. This setting is specific to a particular analysis database.",
+            "ignore": ["SettingsUserScope", "SettingsProjectScope"],
         },
     ),
 ]

--- a/actions.py
+++ b/actions.py
@@ -485,7 +485,6 @@ class MultipleHashLookupTask(BackgroundTaskThread):
             self.hashdb_algorithm, self.hash_values, self.hashdb_api_url
         )
 
-        hashdb_xor_key = Settings().get_string_with_scope("hashdb.xor_key", self.bv)[0]
 
         for collected_hash_value in collected_hash_values:
             if isinstance(collected_hash_value, api.HashDBError):

--- a/actions.py
+++ b/actions.py
@@ -391,7 +391,7 @@ def hash_lookup(context: UIActionContext) -> None:
         if selected_integer_value is not None:
             logger.log_debug(f"Found value {selected_integer_value:#x}")
 
-            if hashdb_xor_key is not None or hashdb_xor_key != "":
+            if hashdb_xor_key is not None and hashdb_xor_key != "":
                 hashdb_xor_key = int(hashdb_xor_key, 16)
                 logger.log_debug(f"XORing value {selected_integer_value:#x} with {hashdb_xor_key:#x}")
                 selected_integer_value = selected_integer_value ^ hashdb_xor_key

--- a/actions.py
+++ b/actions.py
@@ -23,6 +23,11 @@ logger = Logger(session_id=0, logger_name=__name__)
 def add_enums(
     bv: BinaryView, enum_name: str, enum_width: int, hash_list: List[api.Hash]
 ) -> None:
+    hashdb_xor_key = Settings().get_string_with_scope("hashdb.xor_key", bv)[0]
+    if hashdb_xor_key is not None or hashdb_xor_key != "":
+        hashdb_xor_key = int(hashdb_xor_key, 16)
+    for i in range(0, len(hash_list)):
+        hash_list[i].value = hash_list[i].value ^ hashdb_xor_key
     existing_type = bv.types.get(enum_name)
     if existing_type is None:
         # Create a new enum
@@ -307,11 +312,18 @@ def hash_lookup(context: UIActionContext) -> None:
         hashdb_algorithm_data_type
     )
 
+    hashdb_xor_key = Settings().get_string_with_scope("hashdb.xor_key", bv)[0]
+
     if context.token.token:
         token = context.token.token
         if token.type == InstructionTextTokenType.IntegerToken:
             logger.log_debug(f"Integer token found: {token.value:#x}")
             hash_value = token.value
+
+            if hashdb_xor_key is not None or hashdb_xor_key != "":
+                hashdb_xor_key = int(hashdb_xor_key, 16)
+                logger.log_debug(f"XORing value {hash_value:#x} with {hashdb_xor_key:#x}")
+                hash_value = hash_value ^ hashdb_xor_key
 
             HashLookupTask(
                 bv=bv,
@@ -378,6 +390,12 @@ def hash_lookup(context: UIActionContext) -> None:
 
         if selected_integer_value is not None:
             logger.log_debug(f"Found value {selected_integer_value:#x}")
+
+            if hashdb_xor_key is not None or hashdb_xor_key != "":
+                hashdb_xor_key = int(hashdb_xor_key, 16)
+                logger.log_debug(f"XORing value {selected_integer_value:#x} with {hashdb_xor_key:#x}")
+                selected_integer_value = selected_integer_value ^ hashdb_xor_key
+
             HashLookupTask(
                 bv=bv,
                 hashdb_api_url=hashdb_api_url,
@@ -466,6 +484,8 @@ class MultipleHashLookupTask(BackgroundTaskThread):
         collected_hash_values = api.get_strings_from_hashes(
             self.hashdb_algorithm, self.hash_values, self.hashdb_api_url
         )
+
+        hashdb_xor_key = Settings().get_string_with_scope("hashdb.xor_key", self.bv)[0]
 
         for collected_hash_value in collected_hash_values:
             if isinstance(collected_hash_value, api.HashDBError):
@@ -627,6 +647,14 @@ def multiple_hash_lookup(context: UIActionContext) -> None:
         for selected_integer_value in selected_integer_values:
             logger.log_debug(f"Found value {selected_integer_value:#x}")
 
+        hashdb_xor_key = Settings().get_string_with_scope("hashdb.xor_key", bv)[0]
+
+        if hashdb_xor_key is not None or hashdb_xor_key != "":
+                hashdb_xor_key = int(hashdb_xor_key, 16)
+                for i in range(0, len(selected_integer_values)):
+                    logger.log_debug(f"XORing value {selected_integer_values[i]:#x} with {hashdb_xor_key:#x}")
+                    selected_integer_values[i] = selected_integer_values[i] ^ hashdb_xor_key        
+
         MultipleHashLookupTask(
             bv=bv,
             hashdb_api_url=hashdb_api_url,
@@ -658,7 +686,13 @@ class HuntAlgorithmTask(BackgroundTaskThread):
         self.context = context
         self.bv = bv
         self.hashdb_api_url = hashdb_api_url
-        self.hash_value = hash_value
+
+        hashdb_xor_key = Settings().get_string_with_scope("hashdb.xor_key", bv)[0]
+
+        if hashdb_xor_key is None or hashdb_xor_key == "":
+            self.hash_value = hash_value
+        else:
+            self.hash_value = hash_value ^ int(hashdb_xor_key, 16)
 
     def run(self):
         match_results = self.call_hunt_api(self.hashdb_api_url, self.hash_value)

--- a/actions.py
+++ b/actions.py
@@ -648,7 +648,7 @@ def multiple_hash_lookup(context: UIActionContext) -> None:
 
         hashdb_xor_key = Settings().get_string_with_scope("hashdb.xor_key", bv)[0]
 
-        if hashdb_xor_key is not None or hashdb_xor_key != "":
+        if hashdb_xor_key is not None and hashdb_xor_key != "":
                 hashdb_xor_key = int(hashdb_xor_key, 16)
                 for i in range(0, len(selected_integer_values)):
                     logger.log_debug(f"XORing value {selected_integer_values[i]:#x} with {hashdb_xor_key:#x}")

--- a/actions.py
+++ b/actions.py
@@ -24,10 +24,10 @@ def add_enums(
     bv: BinaryView, enum_name: str, enum_width: int, hash_list: List[api.Hash]
 ) -> None:
     hashdb_xor_key = Settings().get_string_with_scope("hashdb.xor_key", bv)[0]
-    if hashdb_xor_key is not None or hashdb_xor_key != "":
+    if hashdb_xor_key is not None and hashdb_xor_key != "":
         hashdb_xor_key = int(hashdb_xor_key, 16)
-    for i in range(0, len(hash_list)):
-        hash_list[i].value = hash_list[i].value ^ hashdb_xor_key
+        for i in range(0, len(hash_list)):
+            hash_list[i].value = hash_list[i].value ^ hashdb_xor_key
     existing_type = bv.types.get(enum_name)
     if existing_type is None:
         # Create a new enum

--- a/actions.py
+++ b/actions.py
@@ -320,7 +320,7 @@ def hash_lookup(context: UIActionContext) -> None:
             logger.log_debug(f"Integer token found: {token.value:#x}")
             hash_value = token.value
 
-            if hashdb_xor_key is not None or hashdb_xor_key != "":
+            if hashdb_xor_key is not None and hashdb_xor_key != "":
                 hashdb_xor_key = int(hashdb_xor_key, 16)
                 logger.log_debug(f"XORing value {hash_value:#x} with {hashdb_xor_key:#x}")
                 hash_value = hash_value ^ hashdb_xor_key


### PR DESCRIPTION
Added an option to specify optional XOR key to use with each hash value (common technique used by malware authors). Similar option already exists in hashdb-ida.

I find it useful sometimes and decided to implement the functionality for it. Please let me know if everything is acceptable and can be merged.

![image](https://github.com/cxiao/hashdb_bn/assets/43863412/13f3d6b7-b865-46db-a2b1-39fe96222b4d)
![HashDB-Settings](https://github.com/cxiao/hashdb_bn/assets/43863412/9b0c672c-9ed2-4210-9067-ad7c4b5011dd)
![image](https://github.com/cxiao/hashdb_bn/assets/43863412/68ec231a-9f85-4d71-bf6e-1bbb3152d37a)
![image](https://github.com/cxiao/hashdb_bn/assets/43863412/202b6d2c-e9b6-41e8-aed6-90ea019df0f7)

